### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -903,21 +903,3 @@ clean:
 	rm -fr *.mod.c *.mod *.o .*.cmd *.ko *~
 	rm -fr .tmp_versions
 endif
-
-############ ANDROID COMMON KERNEL ############
-# Convert to absolute path
-ifneq ($(srctree),)
-_EXTRA_CFLAGS :=
-_INC_CFLAGS :=
-$(foreach flag,$(EXTRA_CFLAGS),\
- $(if $(shell echo $(flag) | grep "\-I"),\
-  $(eval _INC_CFLAGS += $(flag)),\
-  $(eval _EXTRA_CFLAGS += $(flag))\
- )\
-)
-_INC_CFLAGS := \
-$(foreach flag,$(subst -I,,$(_INC_CFLAGS)),\
- $(shell if test -d $(srctree)/$(flag); then echo -I$$(cd $(srctree)/$(flag) && pwd); else echo -I$(flag); fi)\
-)
-EXTRA_CFLAGS := $(_EXTRA_CFLAGS) $(_INC_CFLAGS)
-endif


### PR DESCRIPTION
Removed the Android Common Kernel bit
This fixes the common error of 
"drv_types.h, no such file or directory"